### PR TITLE
Renamed "Personal Notes" to "Notes" to avoid confusion.

### DIFF
--- a/en-US/client.yml
+++ b/en-US/client.yml
@@ -590,7 +590,7 @@ users:
       privacy: "Privacy"
       started: "Started"
       finished: "Finished"
-      notes: "Personal Notes"
+      notes: "Notes"
       remove: "Remove from Library"
       save: "Save Changes"
       saving: "Saving..."


### PR DESCRIPTION
Users mistakenly think that their notes will be private.